### PR TITLE
Bump the version to 0.3.2.

### DIFF
--- a/configtools.spec
+++ b/configtools.spec
@@ -1,5 +1,5 @@
 Name:        configtools
-Version:     0.3.1
+Version:     0.3.2
 Release:     1
 Summary:     The configtools module
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from distutils.core import setup
 
 setup(name = 'configtools',
-      version = '0.3.1',
+      version = '0.3.2',
       description = 'Simple set of tools to read and parse configuration files for use by shell scripts',
       author = 'Nick Dokos',
       author_email = 'ndokos@redhat.com',


### PR DESCRIPTION
We need to bump the version before producing PyPI and COPR artifacts to allow pip and the various spec files to request the version that fixes the `SafeConfigParser` deprecation warnings.